### PR TITLE
Fix format_ty for a list of types

### DIFF
--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -163,9 +163,9 @@ format_ty({object, Fields}) ->
 format_ty({enum, Ty}) ->
     Inner = format_ty(Ty),
     <<"{enum, ", Inner/binary, "}">>;
-format_ty([Ty]) ->
-    Inner = format_ty(Ty),
-    <<"[", Inner/binary, "]">>;
+format_ty(Types) when is_list(Types)->
+    Inners = lists:join(", ", [format_ty(Ty) || Ty <- Types]),
+    iolist_to_binary(["[", Inners, "]"]);
 format_ty({list, Ty}) ->
     Inner = format_ty(Ty),
     <<"{list, ", Inner/binary, "}">>;

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -257,7 +257,7 @@ type_check_err_msg({excess_args, Args}) ->
     io_lib:format("The argument list contains unknown arguments ~p", [Args]);
 type_check_err_msg({type_mismatch, #{ document := Doc, schema := Sch }}) ->
     ["Type mismatch. The query document has a value/variable of type (",
-     graphql_err:format_ty(Doc), ") but the schema expectes type (", graphql_err:format_ty(Sch), ")"];
+     graphql_err:format_ty(Doc), ") but the schema expects type (", graphql_err:format_ty(Sch), ")"];
 type_check_err_msg({type_mismatch, #{ id := ID, document := Doc, schema := Sch }}) ->
     ["Type mismatch on (", ID, "). The query document has a value/variable of type (",
       graphql_err:format_ty(Doc), ") but the schema expects type (", graphql_err:format_ty(Sch), ")"];


### PR DESCRIPTION
This PR fixes a bug causing a crash when the user passes the wrong type value, and that value is present in more than one enum.
Current error message example:
> Type mismatch. The query document has a value/variable of type ([Affiliation, MUCAffiliation]) but the schema expects type (MUCRole)