### PR TITLE
Fix field() type

### DIFF
--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -28,9 +28,9 @@
 
 -record(field, {
 	id :: graphql:name(),
-	args = [] :: [#{ type := graphql_type(),
-                        value := value(),
-                        default := undefined | value() }],
+	args = [] :: [{binary(), #{ type := graphql_type(),
+                                value := value(),
+                                default := undefined | value() }}],
 	directives = [] :: [any()],
 	selection_set = [] :: [any()],
 	alias = undefined :: undefined | graphql:name(),


### PR DESCRIPTION
Fix field() type. This type was incorrect. I'm not sure that now this type is 100% correct, but it fixes the MIM dialyzer. 